### PR TITLE
Implement gem sign

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     ruby-sigstore (0.1.0)
+      launchy
       openid_connect (~> 1.2, >= 1.2.0)
 
 GEM
@@ -15,6 +16,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
     attr_required (1.0.1)
     bindata (2.4.8)
@@ -28,6 +31,8 @@ GEM
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
+    launchy (2.5.0)
+      addressable (~> 2.7)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     mini_mime (1.0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,36 @@ PATH
   remote: .
   specs:
     ruby-sigstore (0.1.0)
+      openid_connect (~> 1.2, >= 1.2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (6.1.3.1)
+      activesupport (= 6.1.3.1)
+    activesupport (6.1.3.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    aes_key_wrap (1.1.0)
+    attr_required (1.0.1)
+    bindata (2.4.8)
+    concurrent-ruby (1.1.8)
     diff-lcs (1.4.4)
     hashie (4.1.0)
+    httpclient (2.8.3)
+    i18n (1.8.9)
+      concurrent-ruby (~> 1.0)
+    json-jwt (1.13.0)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      bindata
+    mail (2.7.1)
+      mini_mime (>= 0.1.1)
+    mini_mime (1.0.3)
+    minitest (5.14.4)
     oa-core (0.0.3)
       rack
     oa-openid (0.0.2)
@@ -20,7 +44,24 @@ GEM
     omniauth-openid (2.0.1)
       omniauth (>= 1.0, < 3.0)
       rack-openid (~> 1.4.0)
+    openid_connect (1.2.0)
+      activemodel
+      attr_required (>= 1.0.0)
+      json-jwt (>= 1.5.0)
+      rack-oauth2 (>= 1.6.1)
+      swd (>= 1.0.0)
+      tzinfo
+      validate_email
+      validate_url
+      webfinger (>= 1.0.1)
+    public_suffix (4.0.6)
     rack (2.2.3)
+    rack-oauth2 (1.16.0)
+      activesupport
+      attr_required
+      httpclient
+      json-jwt (>= 1.11.0)
+      rack (>= 2.1.0)
     rack-openid (1.4.2)
       rack (>= 1.1.0)
       ruby-openid (>= 2.1.8)
@@ -43,6 +84,22 @@ GEM
     ruby-openid (2.9.2)
     ruby-openid-apps-discovery (1.2.0)
       ruby-openid (>= 2.1.7)
+    swd (1.2.0)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      httpclient (>= 2.4)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    validate_email (0.1.6)
+      activemodel (>= 3.0)
+      mail (>= 2.2.5)
+    validate_url (1.0.13)
+      activemodel (>= 3.0.0)
+      public_suffix
+    webfinger (1.1.0)
+      activesupport
+      httpclient (>= 2.4)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
@@ -57,4 +114,4 @@ DEPENDENCIES
   ruby-sigstore!
 
 BUNDLED WITH
-   2.2.3
+   2.2.15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,9 @@ GEM
       validate_email
       validate_url
       webfinger (>= 1.0.1)
+    pp (0.2.0)
+      prettyprint
+    prettyprint (0.1.0)
     public_suffix (4.0.6)
     rack (2.2.3)
     rack-oauth2 (1.16.0)
@@ -108,6 +111,7 @@ PLATFORMS
 DEPENDENCIES
   oa-openid
   omniauth-openid
+  pp (= 0.2.0)
   rake (~> 12.0)
   rspec (~> 3.0)
   ruby-openid-apps-discovery

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: "3"
+volumes:
+  bundle:       { driver: local }
+  config:       { driver: local }
+services:
+  app:
+    image: alpinelab/ruby-dev:2.7
+    volumes:
+      - .:/app
+      - bundle:/bundle
+      - config:/config

--- a/lib/rubygems/commands/sign_command.rb
+++ b/lib/rubygems/commands/sign_command.rb
@@ -51,7 +51,13 @@ class Gem::Commands::SignCommand < Gem::Command
     )
     puts authorization_uri
     
-    Launchy.open(authorization_uri)
+    begin
+      Launchy.open(authorization_uri)
+    rescue
+      # NOTE: ignore any exception, as the URL is printed above and may be
+      #       opened manually
+      puts "Cannot open browser automatically, please click on the link above"
+    end
   end
 
   private

--- a/lib/rubygems/commands/sign_command.rb
+++ b/lib/rubygems/commands/sign_command.rb
@@ -1,12 +1,77 @@
+require 'rubygems/command'
+
+require "openid_connect"
+
 class Gem::Commands::SignCommand < Gem::Command
   def initialize
-    super 'sign', 'Sign'
-    add_option('--fulcio-host HOST', 'Fulcio host') do |value, options|
-      options[:host] = value
-    end
+    super "sign", "Sign a gem"
+    set_options
+  end
+
+  def arguments # :nodoc:
+    "GEMNAME        name of gem to sign"
+  end
+  
+  def defaults_str # :nodoc:
+    ""
+  end
+
+  def usage # :nodoc:
+    "gem sign GEMNAME"
   end
 
   def execute
     puts "sign"
+
+    options[:issuer] = "https://accounts.google.com"
+    options[:client] = "237800849078-rmntmr1b2tcu20kpid66q5dbh1vdt7aj.apps.googleusercontent.com"
+    options[:secret] = "CkkuDoCgE2D_CCRRMyF_UIhS"
+
+    session = {}
+    session[:state] = SecureRandom.hex(16)
+    session[:nonce] = SecureRandom.hex(16)
+
+    result = OpenIDConnect::Discovery::Provider::Config.discover! options[:issuer]
+    pp result
+    
+    client = OpenIDConnect::Client.new(
+      authorization_endpoint: result.authorization_endpoint,
+      identifier: options[:client],
+      redirect_uri: "http://localhost:5556/auth/callback",
+      secret: options[:secret],
+      token_endpoint: result.token_endpoint,
+    )
+    pp client
+
+    authorization_uri = client.authorization_uri(
+      scope: ["openid", :email],
+      state: session[:state],
+      nonce: session[:nonce]
+    )
+    puts authorization_uri
+    
+    # NOTE: this do not work across OS
+    `xdg-open "#{authorization_uri}"`
+  end
+
+  private
+
+  def set_options
+    add_option("--fulcio-host HOST", "Fulcio host") do |value, options|
+      options[:host] = value
+    end
+    add_option("--oidc-issuer ISSUER", "OIDC provider to be used to issue ID token") do |value, options|
+      options[:issuer] = value
+    end
+    add_option("--oidc-client-id CLIENT", "Client ID for application") do |value, options|
+      options[:client] = value
+    end
+    # THIS IS NOT A SECRET - IT IS USED IN THE NATIVE/DESKTOP FLOW.
+    add_option("--oidc-client-secret SECRET", "Client secret for application") do |value, options|
+      options[:secret] = value
+    end
+    add_option("--output FILE", "output file to write certificate chain to") do |value, options|
+      options[:file] = value
+    end
   end
 end

--- a/lib/rubygems/commands/sign_command.rb
+++ b/lib/rubygems/commands/sign_command.rb
@@ -1,5 +1,6 @@
 require 'rubygems/command'
 
+require "launchy"
 require "openid_connect"
 
 class Gem::Commands::SignCommand < Gem::Command
@@ -50,8 +51,7 @@ class Gem::Commands::SignCommand < Gem::Command
     )
     puts authorization_uri
     
-    # NOTE: this do not work across OS
-    `xdg-open "#{authorization_uri}"`
+    Launchy.open(authorization_uri)
   end
 
   private

--- a/ruby-sigstore.gemspec
+++ b/ruby-sigstore.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # spec.add_development_dependency "pp", "0.2.0"
+  spec.add_development_dependency "pp", "0.2.0"
   spec.add_runtime_dependency "openid_connect", "~> 1.2", ">= 1.2.0"
 end

--- a/ruby-sigstore.gemspec
+++ b/ruby-sigstore.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "pp", "0.2.0"
   spec.add_runtime_dependency "openid_connect", "~> 1.2", ">= 1.2.0"
+  spec.add_runtime_dependency "launchy", "~> 2.5"
 end

--- a/ruby-sigstore.gemspec
+++ b/ruby-sigstore.gemspec
@@ -1,4 +1,4 @@
-require_relative 'lib/ruby/sigstore/version'
+require_relative "lib/ruby/sigstore/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "ruby-sigstore"
@@ -20,10 +20,13 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files         = Dir.chdir(File.expand_path("..", __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  # spec.add_development_dependency "pp", "0.2.0"
+  spec.add_runtime_dependency "openid_connect", "~> 1.2", ">= 1.2.0"
 end


### PR DESCRIPTION
Here is the ongoing implementation for `gem sign` command, following along outline from #6 

I'll keep this PR as draft to show progresses.
I'm using [`oicd_connect`](https://rubygems.org/gems/openid_connect) gem as the interface is very similar to the current `fulcio` client implementation.