### PR TITLE
Implements jwt handling, proof challenge and fulcio post

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,10 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ruby-sigstore.gemspec
 gemspec
-gem "oa-openid"
-gem 'omniauth-openid'
-gem 'ruby-openid-apps-discovery'
+gem "faraday_middleware", "~> 1.0.0"
+gem "oa-openid", "~> 0.0.2"
+gem "omniauth-openid", "~> 2.0.1"
+gem "ruby-openid-apps-discovery", "~> 1.2.0"
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
+gem "json-jwt", "~> 1.13.0"

--- a/lib/ruby/sigstore/crypto.rb
+++ b/lib/ruby/sigstore/crypto.rb
@@ -1,11 +1,18 @@
+require 'base64'
 require 'openssl'
 
 class Crypto 
     def initialize; end
+
     def generate_keys
         key = OpenSSL::PKey::EC.new('prime256v1').generate_key
         pkey = OpenSSL::PKey::EC.new(key.public_key.group)
         pkey.public_key = key.public_key
-        return [key.to_pem, pkey.to_pem]
+        return [key, Base64.encode64(pkey.to_der)]
+    end
+
+    def sign_proof(priv_key, email)
+        proof = priv_key.sign(OpenSSL::Digest::SHA256.new, email)
+        return Base64.encode64(proof)
     end
 end

--- a/lib/ruby/sigstore/http_client.rb
+++ b/lib/ruby/sigstore/http_client.rb
@@ -1,0 +1,16 @@
+require "faraday_middleware"
+
+class HttpClient
+    def initialize; end
+    def get_cert(id_token, proof, pub_key, fulcio_host)
+        connection = Faraday.new do |request|
+            request.authorization :Bearer, id_token.to_s
+            request.url_prefix = fulcio_host
+            request.request :json
+            request.response :json, content_type: /json/
+            request.adapter :net_http
+        end
+        fulcio_response = connection.post("/api/v1/signingCert", { publicKey: { content: pub_key, algorithm: "ecdsa" }, signedEmailAddress: proof})
+        return fulcio_response.body
+    end
+end

--- a/lib/rubygems/commands/sign_command.rb
+++ b/lib/rubygems/commands/sign_command.rb
@@ -1,6 +1,8 @@
 require 'rubygems/command'
 require "ruby/sigstore/crypto"
+require "ruby/sigstore/http_client"
 
+require 'json/jwt'
 require "launchy"
 require "openid_connect"
 require "socket"
@@ -24,7 +26,7 @@ class Gem::Commands::SignCommand < Gem::Command
   end
 
   def execute
-    priv, pub = Crypto.new().generate_keys
+    priv_key, pub_key = Crypto.new().generate_keys
 
     options[:issuer] = "https://oauth2.sigstore.dev/auth"
     options[:client] = "sigstore"
@@ -34,32 +36,31 @@ class Gem::Commands::SignCommand < Gem::Command
     session[:state] = SecureRandom.hex(16)
     session[:nonce] = SecureRandom.hex(16)
 
-    result = OpenIDConnect::Discovery::Provider::Config.discover! options[:issuer]
-    # pp result
-    userinfo_endpoint = result.userinfo_endpoint
+    oidc_discovery = OpenIDConnect::Discovery::Provider::Config.discover! options[:issuer]
+
     client = OpenIDConnect::Client.new(
-      authorization_endpoint: result.authorization_endpoint,
+      authorization_endpoint: oidc_discovery.authorization_endpoint,
       identifier: options[:client],
       redirect_uri: "http://localhost:5678",
       secret: options[:secret],
-      token_endpoint: result.token_endpoint,
+      token_endpoint: oidc_discovery.token_endpoint,
     )
-    pp client
 
     authorization_uri = client.authorization_uri(
       scope: ["openid", :email],
       state: session[:state],
       nonce: session[:nonce]
     )
-    puts authorization_uri
 
     begin
       Launchy.open(authorization_uri)
     rescue
       # NOTE: ignore any exception, as the URL is printed above and may be
       #       opened manually
-      puts "Cannot open browser automatically, please click on the link above"
+      puts "Cannot open browser automatically, please click on the link below:"
+      puts authorization_uri
     end
+
     server = TCPServer.new 5678
     connection = server.accept
     while (input = connection.gets)
@@ -76,20 +77,24 @@ class Gem::Commands::SignCommand < Gem::Command
       state = paramarray[1].partition('=').last
       break
     end
+
     client.authorization_code = code
     access_token = client.access_token!
 
-    # next step is to grab scopes and send to fulcio as part of proof
-    userinfo_client = OpenIDConnect::Client.new(
-      identifier: options[:client],
-      userinfo_endpoint: userinfo_endpoint
-    )
-    scope_token = OpenIDConnect::AccessToken.new(
-      access_token: access_token,
-      client: userinfo_client
-    )
-    userinfo = scope_token.userinfo!
-    puts "Received email scope: " + userinfo.email
+    jwks = JSON.parse(OpenIDConnect.http_client.get_content(oidc_discovery.jwks_uri)).with_indifferent_access
+    public_keys = JSON::JWK::Set.new jwks[:keys]
+
+    begin
+      decoded_access_token = JSON::JWT.decode(access_token.to_s,public_keys)
+    rescue JSON::JWS::VerificationFailed => e
+      abort 'JWT Verification Failed: ' + e.to_s
+    else  #success
+      decode_json = JSON.parse(decoded_access_token.to_json)
+    end
+
+    proof = Crypto.new().sign_proof(priv_key, decode_json["email"])
+    cert_response = HttpClient.new().get_cert(access_token, proof, pub_key, options[:host])
+    puts cert_response
   end
 
   private


### PR DESCRIPTION
* Validate the signing of the JWT
* Extract email direct from token and removed uneeded call to
  user_endpoint
* Implement proof challenge
* HTTP Client to call fulcio signing certs

Signed-off-by: Luke Hinds <lhinds@redhat.com>