### PR TITLE
add flag to skip certain files in the boilerplate header checker

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,18 +1,3 @@
-#
-# Copyright 2021 The Sigstore Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: Verify
 
 on:
@@ -24,7 +9,6 @@ on:
 jobs:
   license-check:
     name: license boilerplate check
-    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -36,5 +20,5 @@ jobs:
       - name: Check license headers
         run: |
           set -e
-          addlicense -l apache -c 'The Sigstore Authors' -v *
+          addlicense -l apache -c 'The Sigstore Authors' -v -skip yml -skip yaml -skip Gemfile *
           git diff --exit-code

--- a/Gemfile
+++ b/Gemfile
@@ -1,17 +1,3 @@
-# Copyright 2021 The Sigstore Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in ruby-sigstore.gemspec

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,17 +1,3 @@
-# Copyright 2021 The Sigstore Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 version: "3"
 volumes:
   bundle:       { driver: local }


### PR DESCRIPTION
made a PR in the addlicense project to skip extensions/files and that got merged (https://github.com/google/addlicense/pull/75) see we can use here now :)


This PR adds the `-skip` flag for certain extensions/files to ignore in the boilerplate header.
for not just the extensions `yml`/`yaml`/`Gemfile`

also, remove the boilerplate for the other yamls files and Gemfile

do we need to add for others?

cc @bobcallaway @lukehinds 