### PR TITLE
update addlicense check

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Check license headers
         run: |
           set -e
-          addlicense -l apache -c 'The Sigstore Authors' -v -skip yml -skip yaml -skip Gemfile *
+          addlicense -l apache -c 'The Sigstore Authors' -v -ignore *.yml -ignore *.yaml -ignore Gemfile *
           git diff --exit-code


### PR DESCRIPTION
the flag `-skip` is deprecated in the `addlicenses` with this merged PR: https://github.com/google/addlicense/pull/84

This PR update the flags to use the `-ignore` instead `-skip`


